### PR TITLE
Fix Cognito invitation emails mangling generated passwords

### DIFF
--- a/infra/stacks/cognito_user_provisioner/handler.py
+++ b/infra/stacks/cognito_user_provisioner/handler.py
@@ -1,0 +1,130 @@
+"""CloudFormation Custom Resource handler for provisioning Cognito users.
+
+Generates a temporary password from an HTML-safe character set, then calls
+AdminCreateUser so Cognito emails the invitation containing that password.
+The user lands in FORCE_CHANGE_PASSWORD and must set a new password on
+first sign-in (unchanged UX).
+
+Why a custom resource and not AWS::Cognito::UserPoolUser?
+  The CloudFormation resource does not expose `TemporaryPassword`, so
+  Cognito auto-generates the password. Cognito's generator is allowed to
+  emit `<`, `>`, `&`, `'`, `"` as symbols, and the default invitation
+  email is HTML with the password interpolated as *raw* text (not escaped).
+  Email clients then silently strip any sequence that parses as a tag,
+  so the rendered password does not match the stored verifier and every
+  sign-in fails with ChallengeResponse=Failure, NoRisk.
+
+  By generating the password ourselves from a safe charset, the password
+  Cognito stores is always equal to the password rendered in the email.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import string
+import urllib.request
+
+import boto3
+from botocore.exceptions import ClientError
+
+cognito = boto3.client("cognito-idp")
+
+# Excludes HTML-special chars (< > & " ') and sentence-punctuation chars (. ,)
+# that collide with the default invitation template. All remaining symbols
+# are recognized as symbols by Cognito's password policy.
+SAFE_SYMBOLS = "!#$%^*_-+="
+PASSWORD_LENGTH = 16
+
+
+def _generate_password() -> str:
+    """Generate a password that satisfies a policy requiring upper, lower, digit, symbol."""
+    alphabet = string.ascii_letters + string.digits + SAFE_SYMBOLS
+    while True:
+        pw = "".join(secrets.choice(alphabet) for _ in range(PASSWORD_LENGTH))
+        if (
+            any(c.islower() for c in pw)
+            and any(c.isupper() for c in pw)
+            and any(c.isdigit() for c in pw)
+            and any(c in SAFE_SYMBOLS for c in pw)
+        ):
+            return pw
+
+
+def _create_user(user_pool_id: str, email: str, temporary_password: str) -> None:
+    try:
+        cognito.admin_create_user(
+            UserPoolId=user_pool_id,
+            Username=email,
+            TemporaryPassword=temporary_password,
+            UserAttributes=[
+                {"Name": "email", "Value": email},
+                {"Name": "email_verified", "Value": "true"},
+            ],
+            DesiredDeliveryMediums=["EMAIL"],
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "UsernameExistsException":
+            raise
+        # Idempotency: if the stack is re-deployed and the user already exists,
+        # reset the temporary password so the new email contains a valid one.
+        cognito.admin_set_user_password(
+            UserPoolId=user_pool_id,
+            Username=email,
+            Password=temporary_password,
+            Permanent=False,
+        )
+
+
+def _delete_user(user_pool_id: str, email: str) -> None:
+    try:
+        cognito.admin_delete_user(UserPoolId=user_pool_id, Username=email)
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code not in ("UserNotFoundException", "ResourceNotFoundException"):
+            raise
+
+
+def _send_cfn_response(event: dict, context, status: str, physical_id: str, reason: str = "") -> None:
+    body = json.dumps(
+        {
+            "Status": status,
+            "Reason": reason or f"See CloudWatch logs: {context.log_group_name}/{context.log_stream_name}",
+            "PhysicalResourceId": physical_id,
+            "StackId": event["StackId"],
+            "RequestId": event["RequestId"],
+            "LogicalResourceId": event["LogicalResourceId"],
+            "NoEcho": True,
+            "Data": {},
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(
+        event["ResponseURL"],
+        data=body,
+        method="PUT",
+        headers={"Content-Type": "", "Content-Length": str(len(body))},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        resp.read()
+
+
+def handler(event: dict, context) -> None:
+    props = event.get("ResourceProperties", {})
+    user_pool_id = props["UserPoolId"]
+    email = props["Email"]
+    physical_id = f"{user_pool_id}:{email}"
+
+    try:
+        if event["RequestType"] in ("Create", "Update"):
+            _create_user(user_pool_id, email, _generate_password())
+        elif event["RequestType"] == "Delete":
+            _delete_user(user_pool_id, email)
+        else:
+            _send_cfn_response(event, context, "FAILED", physical_id, reason=f"Unknown RequestType: {event['RequestType']}")
+            return
+
+        _send_cfn_response(event, context, "SUCCESS", physical_id)
+    except Exception as exc:  # noqa: BLE001
+        _send_cfn_response(event, context, "FAILED", physical_id, reason=str(exc)[:1000])
+        raise

--- a/infra/stacks/platform_stack.py
+++ b/infra/stacks/platform_stack.py
@@ -32,6 +32,7 @@ from aws_cdk import aws_ssm as ssm
 from aws_cdk import aws_stepfunctions as sfn
 from aws_cdk import aws_stepfunctions_tasks as sfn_tasks
 from aws_cdk import aws_wafv2 as wafv2
+from aws_cdk import custom_resources as cr
 from constructs import Construct
 
 
@@ -1000,6 +1001,16 @@ class PlatformStack(cdk.Stack):
             mfa=cognito.Mfa.OPTIONAL,
             mfa_second_factor=cognito.MfaSecondFactor(sms=False, otp=True),
             standard_threat_protection_mode=cognito.StandardThreatProtectionMode.FULL_FUNCTION,
+            user_invitation=cognito.UserInvitationConfig(
+                email_subject="Your AgentCore Workflow credentials",
+                email_body=(
+                    "<p>Your AgentCore Workflow account is ready.</p>"
+                    "<p>Username:<br><code>{username}</code></p>"
+                    "<p>Temporary password (copy exactly, no surrounding whitespace):<br>"
+                    "<code>{####}</code></p>"
+                    "<p>You will be prompted to set a new password on first sign-in.</p>"
+                ),
+            ),
             removal_policy=RemovalPolicy.DESTROY,
         )
 
@@ -1016,25 +1027,65 @@ class PlatformStack(cdk.Stack):
             refresh_token_validity=Duration.days(7),
         )
 
-        # Pre-create users from context (comma-separated string via env var)
+        # Pre-create users from context (comma-separated string via env var).
+        #
+        # A Lambda-backed Custom Resource generates a temporary password from
+        # an HTML-safe charset (no <, >, &, ', ", ., ,) and passes it to
+        # AdminCreateUser. Cognito emails the invitation containing that
+        # exact password, so what the user sees in their inbox matches what
+        # Cognito stored. The user still lands in FORCE_CHANGE_PASSWORD and
+        # sets a real password on first sign-in.
+        #
+        # This replaces AWS::Cognito::UserPoolUser, which does not expose
+        # TemporaryPassword and so leaves Cognito to auto-generate one —
+        # those generated passwords can contain HTML-special chars that get
+        # silently stripped by email renderers, producing a displayed
+        # password that does not match the stored verifier.
         cognito_users_raw = self.node.try_get_context("cognito_users") or ""
         cognito_users = [e.strip() for e in cognito_users_raw.split(",") if e.strip()] if isinstance(cognito_users_raw, str) else cognito_users_raw
-        for email in cognito_users:
-            cognito.CfnUserPoolUser(
+
+        if cognito_users:
+            provisioner_fn = _lambda.Function(
                 self,
-                f"User-{email.replace('@', '-at-').replace('.', '-')}",
-                user_pool_id=pool.user_pool_id,
-                username=email,
-                desired_delivery_mediums=["EMAIL"],
-                user_attributes=[
-                    cognito.CfnUserPoolUser.AttributeTypeProperty(
-                        name="email", value=email,
-                    ),
-                    cognito.CfnUserPoolUser.AttributeTypeProperty(
-                        name="email_verified", value="true",
-                    ),
-                ],
+                "CognitoUserProvisionerFn",
+                runtime=_lambda.Runtime.PYTHON_3_12,
+                handler="handler.handler",
+                code=_lambda.Code.from_asset("stacks/cognito_user_provisioner"),
+                timeout=Duration.seconds(60),
+                memory_size=256,
+                log_retention=logs.RetentionDays.ONE_MONTH,
+                description="Provisions Cognito users with an HTML-safe generated temporary password",
             )
+            provisioner_fn.add_to_role_policy(
+                iam.PolicyStatement(
+                    actions=[
+                        "cognito-idp:AdminCreateUser",
+                        "cognito-idp:AdminSetUserPassword",
+                        "cognito-idp:AdminDeleteUser",
+                    ],
+                    resources=[pool.user_pool_arn],
+                )
+            )
+
+            provider = cr.Provider(
+                self,
+                "CognitoUserProvisionerProvider",
+                on_event_handler=provisioner_fn,
+                log_retention=logs.RetentionDays.ONE_MONTH,
+            )
+
+            for email in cognito_users:
+                sanitized = email.replace("@", "-at-").replace(".", "-")
+                user_cr = cdk.CustomResource(
+                    self,
+                    f"User-{sanitized}",
+                    service_token=provider.service_token,
+                    properties={
+                        "UserPoolId": pool.user_pool_id,
+                        "Email": email,
+                    },
+                )
+                user_cr.node.add_dependency(pool)
 
         return pool, client
 


### PR DESCRIPTION
Replace AWS::Cognito::UserPoolUser with a Lambda-backed custom resource that generates the temporary password from an HTML-safe charset before calling AdminCreateUser, and override the pool's invitation template to wrap the password in <code> on its own line.

Cognito's default HTML invitation interpolated {####} as raw text, so auto-generated passwords containing <, >, or & were silently stripped by email clients, and a trailing '.' in the template sentence fused with passwords ending in a period. Users then typed a displayed password that did not match the stored verifier, producing NoRisk auth failures.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
