### PR TITLE
Fix deploy.sh frontend build failing on fresh clones

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -286,7 +286,13 @@ build_frontend() {
   # Use CloudFront URL as the API base — CloudFront routes /api/* to API Gateway
   log_info "Building frontend with VITE_API_BASE_URL=${CLOUDFRONT_URL} ..."
   cd "${PROJECT_ROOT}/frontend"
-  npm ci --silent
+  # npm ci requires package-lock.json, which is gitignored in this repo —
+  # fall back to npm install on a fresh clone.
+  if [[ -f package-lock.json ]]; then
+    npm ci --silent
+  else
+    npm install --silent --no-audit --no-fund
+  fi
   VITE_API_BASE_URL="${CLOUDFRONT_URL}" VITE_AWS_REGION="${AWS_REGION}" VITE_COGNITO_USER_POOL_ID="${USER_POOL_ID}" VITE_COGNITO_CLIENT_ID="${USER_POOL_CLIENT_ID}" npm run build
   cd "${PROJECT_ROOT}"
   log_success "Frontend build complete."


### PR DESCRIPTION
## Problem

`scripts/deploy.sh` uses `npm ci` to install frontend dependencies, but `package-lock.json` is gitignored in this repo (.gitignore line 121). On a fresh clone, `npm ci` errors out immediately, so the deploy aborts after the CDK stack is created but **before the frontend is built and uploaded to S3** — leaving CloudFront serving an `AccessDenied` error from the empty bucket.

## Fix

Fall back to `npm install` when `package-lock.json` is absent, keeping `npm ci` for environments that do have a lock file.

## Testing

Reproduced the failure on a fresh clone, applied the fix, and completed a full deploy: frontend built, synced to S3, CloudFront invalidated, site returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)