### PR TITLE
chore(infra): bump aws-cdk-lib 2.261.0 + constructs 10.6.0 together; keep cdk-nag 2.x

### DIFF
--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -2,6 +2,8 @@
 # is import-fragile across minor releases (NagSuppressions availability moved
 # between versions and broke CI on an unpinned `>=` floor), so pin exactly and
 # let Dependabot propose bumps that CI then re-verifies.
-aws-cdk-lib==2.238.0
-constructs==10.4.5
+# NOTE: cdk-nag stays on 2.x — 3.0 removed the NagSuppressions API this stack
+# uses (see stacks/platform/nag_suppressions.py).
+aws-cdk-lib==2.261.0
+constructs==10.6.0
 cdk-nag==2.37.55


### PR DESCRIPTION
Consolidates #17 + #20 (which fail individually — the two pins must move together) and declines #14 (cdk-nag 3.0 removed NagSuppressions, which nag_suppressions.py uses). 47 infra tests pass; cdk synth verified under the CI CLI version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)