### PR TITLE
chore(deps): opentelemetry-sdk >=1.43.0

### DIFF
--- a/backend/requirements-lambda.txt
+++ b/backend/requirements-lambda.txt
@@ -10,6 +10,6 @@ urllib3
 # Used by services/_otel_platform.py to emit spans for every API request
 # the workflow Lambda + deployment Lambda + step handlers receive.
 opentelemetry-api>=1.43.0
-opentelemetry-sdk>=1.41.0
+opentelemetry-sdk>=1.43.0
 opentelemetry-exporter-otlp-proto-http>=1.43.0
 opentelemetry-instrumentation-botocore>=0.64b0


### PR DESCRIPTION
Applies Dependabot #19's one-line floor bump, which conflicted after the sibling OTEL bumps (#9/#11/#16) merged and could not be auto-rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)