### PR TITLE
fix(palette): trim search query before matching (flaky Property 41)

### DIFF
--- a/frontend/src/components/palette/ComponentPalette.tsx
+++ b/frontend/src/components/palette/ComponentPalette.tsx
@@ -349,11 +349,14 @@ export function ComponentPalette({
     new Set(['compute', 'integration', 'security', 'tools', 'connectors'])
   );
 
-  // Filter items based on search query
+  // Filter items based on search query. Trim BEFORE matching — an untrimmed
+  // query like "a " excludes items that contain "a" but not "a " (trailing
+  // whitespace should never change search results); Property 41 checks the
+  // trimmed semantics.
   const filteredItems = useMemo(() => {
     if (!searchQuery.trim()) return PALETTE_ITEMS;
 
-    const query = searchQuery.toLowerCase();
+    const query = searchQuery.trim().toLowerCase();
     return PALETTE_ITEMS.filter(
       (item) =>
         item.label.toLowerCase().includes(query) ||

--- a/frontend/src/utils/paletteSearch.test.ts
+++ b/frontend/src/utils/paletteSearch.test.ts
@@ -20,7 +20,11 @@ import { PALETTE_ITEMS, type PaletteItem } from '../components/palette/Component
 export function filterPaletteItems(items: PaletteItem[], query: string): PaletteItem[] {
   if (!query.trim()) return items;
 
-  const normalizedQuery = query.toLowerCase();
+  // Trim BEFORE matching (mirrors ComponentPalette): a query like "a " must
+  // match the same items as "a" — trailing whitespace never changes results.
+  // Without the trim, the exclusion property fails on counterexamples like
+  // "A " (item contains "a" but not "a ").
+  const normalizedQuery = query.trim().toLowerCase();
   return items.filter(
     (item) =>
       item.label.toLowerCase().includes(normalizedQuery) ||


### PR DESCRIPTION
Fixes the intermittent `paletteSearch` property-test failure (seen on the main CI run after #35, and inside #34's run): the filter trimmed the query only for the emptiness check but matched with the untrimmed string, so a query with trailing whitespace ('A ') wrongly excluded items. Trailing/leading whitespace now never changes results. Verified across 5 randomized fast-check runs + full suite (253 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)